### PR TITLE
Fix RPM binary name and run release job on workflow_dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,7 +239,7 @@ jobs:
     name: Create GitHub Release
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
     steps:

--- a/gui/forge.config.ts
+++ b/gui/forge.config.ts
@@ -20,7 +20,7 @@ function opt(...paths: string[]): string[] {
 const makers: ForgeConfig['makers'] = [
   new MakerSquirrel({ authors: 'StochFit Contributors' }),
   new MakerDeb({}),
-  new MakerRpm({}),
+  new MakerRpm({ options: { bin: 'stochfit' } }),
 ];
 
 if (process.platform === 'darwin') {


### PR DESCRIPTION
MakerRpm was looking for 'stochfit-gui' (from package.json name) instead of 'stochfit' (executableName); pass bin explicitly to electron-installer-redhat.

Release job condition expanded to also fire on workflow_dispatch so manually triggered builds attach installers to a GitHub Release.