### PR TITLE
Fix deb binary name lookup same as rpm

### DIFF
--- a/gui/forge.config.ts
+++ b/gui/forge.config.ts
@@ -19,7 +19,7 @@ function opt(...paths: string[]): string[] {
 // macOS so that `npm install` succeeds on Windows/Linux (optionalDependency).
 const makers: ForgeConfig['makers'] = [
   new MakerSquirrel({ authors: 'StochFit Contributors' }),
-  new MakerDeb({}),
+  new MakerDeb({ options: { bin: 'stochfit' } }),
   new MakerRpm({ options: { bin: 'stochfit' } }),
 ];
 


### PR DESCRIPTION
electron-installer-debian also reads binary name from package.json name field; pass bin: 'stochfit' explicitly to match executableName.