### PR TITLE
Replace MakerRpm with MakerZip for Linux distribution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,7 +233,7 @@ jobs:
           name: installer-linux
           path: |
             build/electron/out/make/deb/**/*.deb
-            build/electron/out/make/rpm/**/*.rpm
+            build/electron/out/make/zip/linux/**/*.zip
 
   release:
     name: Create GitHub Release

--- a/gui/forge.config.ts
+++ b/gui/forge.config.ts
@@ -1,7 +1,7 @@
 import type { ForgeConfig } from '@electron-forge/shared-types';
 import { MakerSquirrel } from '@electron-forge/maker-squirrel';
 import { MakerDeb } from '@electron-forge/maker-deb';
-import { MakerRpm } from '@electron-forge/maker-rpm';
+import { MakerZip } from '@electron-forge/maker-zip';
 import { VitePlugin } from '@electron-forge/plugin-vite';
 import { existsSync } from 'fs';
 import { resolve } from 'path';
@@ -20,7 +20,7 @@ function opt(...paths: string[]): string[] {
 const makers: ForgeConfig['makers'] = [
   new MakerSquirrel({ authors: 'StochFit Contributors' }),
   new MakerDeb({ options: { bin: 'stochfit' } }),
-  new MakerRpm({ options: { bin: 'stochfit', license: 'GPL-2.0' } }),
+  new MakerZip({}, ['linux']),
 ];
 
 if (process.platform === 'darwin') {


### PR DESCRIPTION
RPM builds kept failing (missing license field, then other rpmbuild issues). MakerZip produces a self-contained zip of the packaged app with no system package manager dependency.