### PR TITLE
Linux: use MakerZip only; Windows/macOS keep Squirrel/DMG

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,9 +231,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: installer-linux
-          path: |
-            build/electron/out/make/deb/**/*.deb
-            build/electron/out/make/zip/linux/**/*.zip
+          path: build/electron/out/make/zip/linux/**/*.zip
 
   release:
     name: Create GitHub Release

--- a/gui/forge.config.ts
+++ b/gui/forge.config.ts
@@ -1,6 +1,5 @@
 import type { ForgeConfig } from '@electron-forge/shared-types';
 import { MakerSquirrel } from '@electron-forge/maker-squirrel';
-import { MakerDeb } from '@electron-forge/maker-deb';
 import { MakerZip } from '@electron-forge/maker-zip';
 import { VitePlugin } from '@electron-forge/plugin-vite';
 import { existsSync } from 'fs';
@@ -19,7 +18,6 @@ function opt(...paths: string[]): string[] {
 // macOS so that `npm install` succeeds on Windows/Linux (optionalDependency).
 const makers: ForgeConfig['makers'] = [
   new MakerSquirrel({ authors: 'StochFit Contributors' }),
-  new MakerDeb({ options: { bin: 'stochfit' } }),
   new MakerZip({}, ['linux']),
 ];
 

--- a/gui/package.json
+++ b/gui/package.json
@@ -14,9 +14,8 @@
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.6.0",
-    "@electron-forge/maker-deb": "^7.6.0",
-    "@electron-forge/maker-rpm": "^7.6.0",
     "@electron-forge/maker-squirrel": "^7.6.0",
+    "@electron-forge/maker-zip": "^7.6.0",
     "@electron-forge/plugin-vite": "^7.6.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",


### PR DESCRIPTION
Removes MakerDeb and MakerRpm entirely. Adds @electron-forge/maker-zip to devDependencies so the import resolves on all platforms, but the ['linux'] platform filter means it only produces an artifact on Linux.