### PR TITLE
Disable macOS code signing and notarization

### DIFF
--- a/gui/forge.config.ts
+++ b/gui/forge.config.ts
@@ -35,6 +35,8 @@ const config: ForgeConfig = {
     asar: false,
     name: 'StochFit',
     executableName: 'stochfit',
+    osxSign: false,
+    osxNotarize: false,
     ignore: [],
     extraResource: [
       // Core native libraries


### PR DESCRIPTION
App is unsigned; explicitly disable so Gatekeeper shows 'unverified developer' instead of 'damaged'. Users can right-click -> Open to run.